### PR TITLE
feat: allow only posts requests

### DIFF
--- a/services/api/api.js
+++ b/services/api/api.js
@@ -5,6 +5,11 @@ const ApiService = require('moleculer-web')
 module.exports = {
   mixins: [ApiService],
   settings: {
+    routes: [{
+      aliases: {
+        'POST email': 'email.send'
+      }
+    }],
     port: process.env.PORT || '5001',
     cors: {
       origin: ALLOWED_ORIGINS ? ALLOWED_ORIGINS.split(', ') : ''


### PR DESCRIPTION
Breaking changes:
1. restrict api calls to only post method to send emails
2. /email/send is changed to /email